### PR TITLE
Bugfix UPCAReader

### DIFF
--- a/core/src/zxing/common/CharacterSetECI.cpp
+++ b/core/src/zxing/common/CharacterSetECI.cpp
@@ -24,8 +24,8 @@ using std::string;
 using zxing::common::CharacterSetECI;
 using zxing::IllegalArgumentException;
 
-std::map<int, CharacterSetECI*> CharacterSetECI::VALUE_TO_ECI;
-std::map<std::string, CharacterSetECI*> CharacterSetECI::NAME_TO_ECI;
+std::map<int, zxing::Ref<CharacterSetECI>> CharacterSetECI::VALUE_TO_ECI;
+std::map<std::string, zxing::Ref<CharacterSetECI>> CharacterSetECI::NAME_TO_ECI;
 
 const bool CharacterSetECI::inited = CharacterSetECI::init_tables();
 
@@ -72,11 +72,12 @@ bool CharacterSetECI::init_tables() {
 CharacterSetECI::CharacterSetECI(int const* values,
                                  char const* const* names) 
   : values_(values), names_(names) {
+  zxing::Ref<CharacterSetECI> this_ref(this);
   for(int const* values = values_; *values != -1; values++) {
-    VALUE_TO_ECI[*values] = this;
+    VALUE_TO_ECI[*values] = this_ref;
   }
   for(char const* const* names = names_; *names; names++) {
-    NAME_TO_ECI[string(*names)] = this;
+    NAME_TO_ECI[string(*names)] = this_ref;
   }
 }
 

--- a/core/src/zxing/common/CharacterSetECI.h
+++ b/core/src/zxing/common/CharacterSetECI.h
@@ -25,10 +25,10 @@
 namespace zxing {
 namespace common {
 
-class CharacterSetECI {
+class CharacterSetECI : public Counted {
 private:
-  static std::map<int, CharacterSetECI*> VALUE_TO_ECI;
-  static std::map<std::string, CharacterSetECI*> NAME_TO_ECI;
+  static std::map<int, zxing::Ref<CharacterSetECI>> VALUE_TO_ECI;
+  static std::map<std::string, zxing::Ref<CharacterSetECI>> NAME_TO_ECI;
   static const bool inited;
   static bool init_tables();
 

--- a/core/src/zxing/common/detector/MonochromeRectangleDetector.cpp
+++ b/core/src/zxing/common/detector/MonochromeRectangleDetector.cpp
@@ -22,6 +22,7 @@
 #include <zxing/NotFoundException.h>
 #include <zxing/common/detector/MonochromeRectangleDetector.h>
 #include <sstream>
+#include <algorithm>  // vs12, std::min und std:max
 
 using std::vector;
 using zxing::Ref;

--- a/core/src/zxing/common/reedsolomon/GenericGF.cpp
+++ b/core/src/zxing/common/reedsolomon/GenericGF.cpp
@@ -67,10 +67,10 @@ void GenericGF::initialize() {
   }
   //logTable[0] == 0 but this should never be used
   zero =
-    Ref<GenericGFPoly>(new GenericGFPoly(Ref<GenericGF>(this), ArrayRef<int>(new Array<int>(1))));
+    Ref<GenericGFPoly>(new GenericGFPoly(*this, ArrayRef<int>(new Array<int>(1))));
   zero->getCoefficients()[0] = 0;
   one =
-    Ref<GenericGFPoly>(new GenericGFPoly(Ref<GenericGF>(this), ArrayRef<int>(new Array<int>(1))));
+    Ref<GenericGFPoly>(new GenericGFPoly(*this, ArrayRef<int>(new Array<int>(1))));
   one->getCoefficients()[0] = 1;
   initialized = true;
 }
@@ -103,7 +103,7 @@ Ref<GenericGFPoly> GenericGF::buildMonomial(int degree, int coefficient) {
   ArrayRef<int> coefficients(new Array<int>(degree + 1));
   coefficients[0] = coefficient;
     
-  return Ref<GenericGFPoly>(new GenericGFPoly(Ref<GenericGF>(this), coefficients));
+  return Ref<GenericGFPoly>(new GenericGFPoly(*this, coefficients));
 }
   
 int GenericGF::addOrSubtract(int a, int b) {

--- a/core/src/zxing/common/reedsolomon/GenericGFPoly.cpp
+++ b/core/src/zxing/common/reedsolomon/GenericGFPoly.cpp
@@ -31,7 +31,7 @@ using zxing::Ref;
 // VC++
 using zxing::GenericGF;
 
-GenericGFPoly::GenericGFPoly(Ref<GenericGF> field,
+GenericGFPoly::GenericGFPoly(GenericGF &field,
                              ArrayRef<int> coefficients)
   :  field_(field) {
   if (coefficients->size() == 0) {
@@ -45,7 +45,7 @@ GenericGFPoly::GenericGFPoly(Ref<GenericGF> field,
       firstNonZero++;
     }
     if (firstNonZero == coefficientsLength) {
-      coefficients_ = field->getZero()->getCoefficients();
+      coefficients_ = field.getZero()->getCoefficients();
     } else {
       coefficients_ = ArrayRef<int>(new Array<int>(coefficientsLength-firstNonZero));
       for (int i = 0; i < (int)coefficients_->size(); i++) {
@@ -90,13 +90,13 @@ int GenericGFPoly::evaluateAt(int a) {
   }
   int result = coefficients_[0];
   for (int i = 1; i < size; i++) {
-    result = GenericGF::addOrSubtract(field_->multiply(a, result), coefficients_[i]);
+    result = GenericGF::addOrSubtract(field_.multiply(a, result), coefficients_[i]);
   }
   return result;
 }
   
 Ref<GenericGFPoly> GenericGFPoly::addOrSubtract(Ref<zxing::GenericGFPoly> other) {
-  if (!(field_.object_ == other->field_.object_)) {
+  if (!(&field_ == &other->field_)) {
     throw IllegalArgumentException("GenericGFPolys do not have same GenericGF field");
   }
   if (isZero()) {
@@ -130,12 +130,12 @@ Ref<GenericGFPoly> GenericGFPoly::addOrSubtract(Ref<zxing::GenericGFPoly> other)
 }
   
 Ref<GenericGFPoly> GenericGFPoly::multiply(Ref<zxing::GenericGFPoly> other) {
-  if (!(field_.object_ == other->field_.object_)) {
+  if (!(&field_ == &other->field_)) {
     throw IllegalArgumentException("GenericGFPolys do not have same GenericGF field");
   }
     
   if (isZero() || other->isZero()) {
-    return field_->getZero();
+    return field_.getZero();
   }
     
   ArrayRef<int> aCoefficients = coefficients_;
@@ -149,7 +149,7 @@ Ref<GenericGFPoly> GenericGFPoly::multiply(Ref<zxing::GenericGFPoly> other) {
     int aCoeff = aCoefficients[i];
     for (int j = 0; j < bLength; j++) {
       product[i+j] = GenericGF::addOrSubtract(product[i+j], 
-                                              field_->multiply(aCoeff, bCoefficients[j]));
+                                              field_.multiply(aCoeff, bCoefficients[j]));
     }
   }
     
@@ -158,7 +158,7 @@ Ref<GenericGFPoly> GenericGFPoly::multiply(Ref<zxing::GenericGFPoly> other) {
   
 Ref<GenericGFPoly> GenericGFPoly::multiply(int scalar) {
   if (scalar == 0) {
-    return field_->getZero();
+    return field_.getZero();
   }
   if (scalar == 1) {
     return Ref<GenericGFPoly>(this);
@@ -166,7 +166,7 @@ Ref<GenericGFPoly> GenericGFPoly::multiply(int scalar) {
   int size = coefficients_->size();
   ArrayRef<int> product(new Array<int>(size));
   for (int i = 0; i < size; i++) {
-    product[i] = field_->multiply(coefficients_[i], scalar);
+    product[i] = field_.multiply(coefficients_[i], scalar);
   }
   return Ref<GenericGFPoly>(new GenericGFPoly(field_, product));
 }
@@ -176,37 +176,37 @@ Ref<GenericGFPoly> GenericGFPoly::multiplyByMonomial(int degree, int coefficient
     throw IllegalArgumentException("degree must not be less then 0");
   }
   if (coefficient == 0) {
-    return field_->getZero();
+    return field_.getZero();
   }
   int size = coefficients_->size();
   ArrayRef<int> product(new Array<int>(size+degree));
   for (int i = 0; i < size; i++) {
-    product[i] = field_->multiply(coefficients_[i], coefficient);
+    product[i] = field_.multiply(coefficients_[i], coefficient);
   }
   return Ref<GenericGFPoly>(new GenericGFPoly(field_, product));
 }
   
 std::vector<Ref<GenericGFPoly> > GenericGFPoly::divide(Ref<GenericGFPoly> other) {
-  if (!(field_.object_ == other->field_.object_)) {
+  if (!(&field_ == &other->field_)) {
     throw IllegalArgumentException("GenericGFPolys do not have same GenericGF field");
   }
   if (other->isZero()) {
     throw IllegalArgumentException("divide by 0");
   }
     
-  Ref<GenericGFPoly> quotient = field_->getZero();
+  Ref<GenericGFPoly> quotient = field_.getZero();
   Ref<GenericGFPoly> remainder = Ref<GenericGFPoly>(this);
     
   int denominatorLeadingTerm = other->getCoefficient(other->getDegree());
-  int inverseDenominatorLeadingTerm = field_->inverse(denominatorLeadingTerm);
+  int inverseDenominatorLeadingTerm = field_.inverse(denominatorLeadingTerm);
     
   while (remainder->getDegree() >= other->getDegree() && !remainder->isZero()) {
     int degreeDifference = remainder->getDegree() - other->getDegree();
-    int scale = field_->multiply(remainder->getCoefficient(remainder->getDegree()),
-                                 inverseDenominatorLeadingTerm);
+    int scale = field_.multiply(remainder->getCoefficient(remainder->getDegree()),
+                                inverseDenominatorLeadingTerm);
     Ref<GenericGFPoly> term = other->multiplyByMonomial(degreeDifference, scale);
-    Ref<GenericGFPoly> iterationQuotiont = field_->buildMonomial(degreeDifference,
-                                                                 scale);
+    Ref<GenericGFPoly> iterationQuotiont = field_.buildMonomial(degreeDifference,
+                                                                scale);
     quotient = quotient->addOrSubtract(iterationQuotiont);
     remainder = remainder->addOrSubtract(term);
   }

--- a/core/src/zxing/common/reedsolomon/GenericGFPoly.h
+++ b/core/src/zxing/common/reedsolomon/GenericGFPoly.h
@@ -32,11 +32,11 @@ class GenericGF;
   
 class GenericGFPoly : public Counted {
 private:
-  Ref<GenericGF> field_;
+  GenericGF &field_;
   ArrayRef<int> coefficients_;
     
 public:
-  GenericGFPoly(Ref<GenericGF> field, ArrayRef<int> coefficients);
+  GenericGFPoly(GenericGF &field, ArrayRef<int> coefficients);
   ArrayRef<int> getCoefficients();
   int getDegree();
   bool isZero();

--- a/core/src/zxing/common/reedsolomon/ReedSolomonDecoder.cpp
+++ b/core/src/zxing/common/reedsolomon/ReedSolomonDecoder.cpp
@@ -40,7 +40,7 @@ ReedSolomonDecoder::~ReedSolomonDecoder() {
 }
 
 void ReedSolomonDecoder::decode(ArrayRef<int> received, int twoS) {
-  Ref<GenericGFPoly> poly(new GenericGFPoly(field, received));
+  Ref<GenericGFPoly> poly(new GenericGFPoly(*field, received));
   ArrayRef<int> syndromeCoefficients(twoS);
   bool noError = true;
   for (int i = 0; i < twoS; i++) {
@@ -53,7 +53,7 @@ void ReedSolomonDecoder::decode(ArrayRef<int> received, int twoS) {
   if (noError) {
     return;
   }
-  Ref<GenericGFPoly> syndrome(new GenericGFPoly(field, syndromeCoefficients));
+  Ref<GenericGFPoly> syndrome(new GenericGFPoly(*field, syndromeCoefficients));
   vector<Ref<GenericGFPoly> > sigmaOmega =
     runEuclideanAlgorithm(field->buildMonomial(twoS, 1), syndrome, twoS);
   Ref<GenericGFPoly> sigma = sigmaOmega[0];

--- a/core/src/zxing/datamatrix/decoder/DecodedBitStreamParser.cpp
+++ b/core/src/zxing/datamatrix/decoder/DecodedBitStreamParser.cpp
@@ -399,7 +399,7 @@ void DecodedBitStreamParser::decodeBase256Segment(Ref<BitSource> bits, ostringst
     throw FormatException("NegativeArraySizeException");
   }
 
-  char* bytes = new char[count];
+  ArrayRef<char> bytes(count);
   for (int i = 0; i < count; i++) {
     // Have seen this particular error in the wild, such as at
     // http://www.bcgen.com/demo/IDAutomationStreamingDataMatrix.aspx?MODE=3&D=Fred&PFMT=3&PT=F&X=0.3&O=0&LM=0.2

--- a/core/src/zxing/datamatrix/decoder/DecodedBitStreamParser.cpp
+++ b/core/src/zxing/datamatrix/decoder/DecodedBitStreamParser.cpp
@@ -399,16 +399,15 @@ void DecodedBitStreamParser::decodeBase256Segment(Ref<BitSource> bits, ostringst
     throw FormatException("NegativeArraySizeException");
   }
 
-  ArrayRef<char> bytes(count);
   for (int i = 0; i < count; i++) {
     // Have seen this particular error in the wild, such as at
     // http://www.bcgen.com/demo/IDAutomationStreamingDataMatrix.aspx?MODE=3&D=Fred&PFMT=3&PT=F&X=0.3&O=0&LM=0.2
     if (bits->available() < 8) {
       throw FormatException("byteSegments");
     }
-    bytes[i] = unrandomize255State(bits->readBits(8), codewordPosition++);
-    byteSegments.push_back(bytes[i]);
-    result << (char)bytes[i];
+    char byte = unrandomize255State(bits->readBits(8), codewordPosition++);
+    byteSegments.push_back(byte);
+    result << byte;
   }
 }
 }

--- a/core/src/zxing/datamatrix/detector/Detector.cpp
+++ b/core/src/zxing/datamatrix/detector/Detector.cpp
@@ -27,6 +27,7 @@
 #include <zxing/NotFoundException.h>
 #include <sstream>
 #include <cstdlib>
+#include <algorithm>  // vs12, std::min und std:max
 
 using std::abs;
 using zxing::Ref;

--- a/core/src/zxing/oned/Code128Reader.cpp
+++ b/core/src/zxing/oned/Code128Reader.cpp
@@ -26,6 +26,7 @@
 #include <math.h>
 #include <string.h>
 #include <sstream>
+#include <algorithm>  // vs12, std::min und std:max
 
 using std::vector;
 using std::string;

--- a/core/src/zxing/oned/Code39Reader.cpp
+++ b/core/src/zxing/oned/Code39Reader.cpp
@@ -23,6 +23,7 @@
 #include <zxing/ChecksumException.h>
 #include <math.h>
 #include <limits.h>
+#include <algorithm>  // vs12, std::min und std:max
 
 using std::vector;
 using zxing::Ref;

--- a/core/src/zxing/oned/OneDReader.cpp
+++ b/core/src/zxing/oned/OneDReader.cpp
@@ -22,6 +22,7 @@
 #include <zxing/NotFoundException.h>
 #include <math.h>
 #include <limits.h>
+#include <algorithm>  // vs12, std::min und std:max
 
 using std::vector;
 using zxing::Ref;

--- a/core/src/zxing/oned/UPCAReader.cpp
+++ b/core/src/zxing/oned/UPCAReader.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "UPCAReader.h"
-#include <zxing/ReaderException.h>
+#include <zxing/FormatException.h>
 
 using zxing::oned::UPCAReader;
 using zxing::Ref;
@@ -29,6 +29,7 @@ using zxing::Result;
 using zxing::BitArray;
 using zxing::BinaryBitmap;
 using zxing::DecodeHints;
+using zxing::FormatException;
 
 UPCAReader::UPCAReader() : ean13Reader() {}
 
@@ -53,17 +54,15 @@ int UPCAReader::decodeMiddle(Ref<BitArray> row,
 }
 
 Ref<Result> UPCAReader::maybeReturnResult(Ref<Result> result) {
-  if (result.empty()) {
-    return result;
-  }
   const std::string& text = (result->getText())->getText();
   if (text[0] == '0') {
     Ref<String> resultString(new String(text.substr(1)));
     Ref<Result> res(new Result(resultString, result->getRawBytes(), result->getResultPoints(),
                                BarcodeFormat::UPC_A));
     return res;
+  } else {
+    throw FormatException();
   }
-  return Ref<Result>();
 }
 
 zxing::BarcodeFormat UPCAReader::getBarcodeFormat(){

--- a/core/src/zxing/pdf417/detector/Detector.cpp
+++ b/core/src/zxing/pdf417/detector/Detector.cpp
@@ -21,6 +21,7 @@
 #include <zxing/common/GridSampler.h>
 #include <zxing/common/detector/JavaMath.h>
 #include <zxing/common/detector/MathUtils.h>
+#include <algorithm>  // vs12, std::min und std:max
 
 using std::max;
 using std::abs;

--- a/core/src/zxing/pdf417/detector/LinesSampler.cpp
+++ b/core/src/zxing/pdf417/detector/LinesSampler.cpp
@@ -20,6 +20,7 @@
 #include <zxing/pdf417/decoder/BitMatrixParser.h>
 #include <zxing/NotFoundException.h>
 #include <zxing/common/Point.h>
+#include <algorithm>  // vs12, std::min und std:max
 
 using std::map;
 using std::vector;

--- a/core/src/zxing/qrcode/detector/Detector.cpp
+++ b/core/src/zxing/qrcode/detector/Detector.cpp
@@ -30,6 +30,7 @@
 #include <zxing/common/detector/MathUtils.h>
 #include <sstream>
 #include <cstdlib>
+#include <algorithm>  // vs12, std::min und std:max
 
 using std::ostringstream;
 using std::abs;


### PR DESCRIPTION
The maybeReturnResult function checks whether the Result is UPCA or EAN13. The old version returned an uninitialised Ref<Result> (at the EAN13 case) which let MultiFormatUPCEANReader::decodeRow (line 90)
crash because a Result is assumed.

The bugfix is technically oriented at the java version.

Note: This error doesn't appear at normal tests because the MultiFormatUPCEANReader
uses the EAN13 reader for UPC-A detection. The UPCAReader is only used if
DecodeHints BarcodeFormat::UPC_A ist set.
