### PR TITLE
Clarify how to build with make

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Usage with CLion or Qt Creator:
 
 Usage with Makefiles, Visual Studio, etc. (see `cmake --help` for a complete list of generators):
 
-  1. `cd` to `cpp/build`
+  1. `mkdir build`
+  2. `cd` to `build`
   3. Unix: run `cmake -G "Unix Makefiles" ..`
   3. Windows: run `cmake -G "Visual Studio 10" ..`
   


### PR DESCRIPTION
The `cpp` appears leftover from the old build system.  Running `cmake .` in the root directory complains that the "Source directory is polluted", so this clarifies the desire to build in a different directory.
