### PR TITLE
Remove Byte Order Mark <U+FEFF>

### DIFF
--- a/core/src/zxing/pdf417/detector/LinesSampler.cpp
+++ b/core/src/zxing/pdf417/detector/LinesSampler.cpp
@@ -1,4 +1,4 @@
-﻿// -*- mode:c++; tab-width:2; indent-tabs-mode:nil; c-basic-offset:2 -*-
+// -*- mode:c++; tab-width:2; indent-tabs-mode:nil; c-basic-offset:2 -*-
 /*
  * Copyright 2010, 2012 ZXing authors All rights reserved.
  *


### PR DESCRIPTION
the commit c4fd6e223cd7b42b16020c3f72558bae6addafcb introduced a BOM at the beginning of the file, which may cause problems.
