### PR TITLE
Fix crash of GenericGFPoly::divide, vector has not been initialized.

### DIFF
--- a/core/src/zxing/common/reedsolomon/GenericGFPoly.cpp
+++ b/core/src/zxing/common/reedsolomon/GenericGFPoly.cpp
@@ -211,7 +211,7 @@ std::vector<Ref<GenericGFPoly> > GenericGFPoly::divide(Ref<GenericGFPoly> other)
     remainder = remainder->addOrSubtract(term);
   }
     
-  std::vector<Ref<GenericGFPoly> > returnValue;
+  std::vector<Ref<GenericGFPoly> > returnValue(2);
   returnValue[0] = quotient;
   returnValue[1] = remainder;
   return returnValue;


### PR DESCRIPTION
Fix crash of GenericGFPoly::divide, vector has not been initialized.
