### PR TITLE
Implement GreyscaleLuminanceSource::crop()

### DIFF
--- a/core/src/zxing/common/GreyscaleLuminanceSource.cpp
+++ b/core/src/zxing/common/GreyscaleLuminanceSource.cpp
@@ -69,6 +69,10 @@ ArrayRef<char> GreyscaleLuminanceSource::getMatrix() const {
   return result;
 }
 
+Ref<LuminanceSource> GreyscaleLuminanceSource::crop(int left, int top, int width, int height) const {
+  return Ref<LuminanceSource>(new GreyscaleLuminanceSource(greyData_, dataWidth_, dataHeight_, left, top, width, height));
+}
+
 Ref<LuminanceSource> GreyscaleLuminanceSource::rotateCounterClockwise() const {
   // Intentionally flip the left, top, width, and height arguments as
   // needed. dataWidth and dataHeight are always kept unrotated.

--- a/core/src/zxing/common/GreyscaleLuminanceSource.h
+++ b/core/src/zxing/common/GreyscaleLuminanceSource.h
@@ -41,6 +41,12 @@ public:
   ArrayRef<char> getRow(int y, ArrayRef<char> row) const;
   ArrayRef<char> getMatrix() const;
 
+  bool isCropSupported() const {
+    return true;
+  }
+
+  Ref<LuminanceSource> crop(int left, int top, int width, int height) const;
+
   bool isRotateSupported() const {
     return true;
   }


### PR DESCRIPTION
I tested this lib with a large image using `GenericMultipleBarcodeReader` and `GreyscaleLuminanceSource` and it throws `IllegalArgumentException("This luminance source does not support cropping.")`.

I read the code and it seems the class already does what looks like cropping in its constructor so I just use it to implement `crop()` and now the code works correctly, thus the PR.

Let me know if this isn't the right fix.
