### PR TITLE
CMakeLists: add rules for installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,10 @@ file(GLOB_RECURSE ZXING_FILES
 )
 add_executable(zxing ${ZXING_FILES})
 target_link_libraries(zxing libzxing)
+install(TARGETS zxing libzxing
+	LIBRARY DESTINATION lib
+	RUNTIME DESTINATION bin)
+install(DIRECTORY core/src/zxing/ DESTINATION include/zxing FILES_MATCHING PATTERN "*.h")
 
 # Add testrunner executable.
 find_package(CPPUNIT)


### PR DESCRIPTION
This commit adds some CMake rules that allow to do a "make install" to
install the zxing binary, its library and corresponding header files.

Signed-off-by: Thomas Petazzoni thomas.petazzoni@free-electrons.com
