### PR TITLE
add ARCHIVE DESTINATION in install step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,8 @@ add_executable(zxing ${ZXING_FILES})
 target_link_libraries(zxing libzxing)
 install(TARGETS zxing libzxing
 	LIBRARY DESTINATION lib
-	RUNTIME DESTINATION bin)
+	RUNTIME DESTINATION bin
+	ARCHIVE DESTINATION lib)
 install(DIRECTORY core/src/zxing/ DESTINATION include/zxing FILES_MATCHING PATTERN "*.h")
 
 # Add testrunner executable.


### PR DESCRIPTION
For static library (*.a) targets we need to specify ARCHIVE DESTINATION. Tested on Ubuntu 14.04 and 15.04.
