### PR TITLE
Fix compiler warning on Mac OSX

### DIFF
--- a/core/src/zxing/pdf417/detector/LinesSampler.cpp
+++ b/core/src/zxing/pdf417/detector/LinesSampler.cpp
@@ -704,7 +704,7 @@ Point LinesSampler::intersection(Line a, Line b) {
   float p = a.start.x * a.end.y - a.start.y * a.end.x;
   float q = b.start.x * b.end.y - b.start.y * b.end.x;
   float denom = dxa * dyb - dya * dxb;
-  if(abs(denom) < 1e-12)  // Lines don't intersect (replaces "denom == 0")
+  if(std::abs(denom) < 1e-12)  // Lines don't intersect (replaces "denom == 0")
     return Point(std::numeric_limits<float>::infinity(),
                  std::numeric_limits<float>::infinity());
 


### PR DESCRIPTION
The following is the warning that shows up when compiling:

LinesSampler.cpp:707:6: 
warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]

  if(abs(denom) < 1e-12)  // Lines don't intersect (replaces "denom == 0")
     ^
LinesSampler.cpp:707:6: note: use function 'std::abs' instead
  if(abs(denom) < 1e-12)  // Lines don't intersect (replaces "denom == 0")
     ^~~
     std::abs

This change does what the warning requests.  
