### PR TITLE
Fixed a logic error in Code 39 that was requiring too much quiet zone.

### DIFF
--- a/core/src/zxing/oned/Code39Reader.cpp
+++ b/core/src/zxing/oned/Code39Reader.cpp
@@ -133,7 +133,7 @@ Ref<Result> Code39Reader::decodeRow(int rowNumber, Ref<BitArray> row) {
   int whiteSpaceAfterEnd = nextStart - lastStart - lastPatternSize;
   // If 50% of last pattern size, following last pattern, is not whitespace,
   // fail (but if it's whitespace to the very end of the image, that's OK)
-  if (nextStart != end && (whiteSpaceAfterEnd >> 1) < lastPatternSize) {
+  if (nextStart != end && (whiteSpaceAfterEnd << 1) < lastPatternSize) {
     throw NotFoundException();
   }
 


### PR DESCRIPTION
Porting over a Code39 fix from the Java library. This was causing me a lot of issues detecting certain codes.

Issue in Java library for reference.
https://github.com/zxing/zxing/issues/86
