### PR TITLE
Fixed declaration in .h file problem with VC++

### DIFF
--- a/core/src/zxing/DecodeHints.cpp
+++ b/core/src/zxing/DecodeHints.cpp
@@ -29,7 +29,31 @@ using zxing::DecodeHints;
 // VC++
 using zxing::BarcodeFormat;
 
-const DecodeHintType DecodeHints::CHARACTER_SET;
+const DecodeHintType DecodeHints::AZTEC_HINT = 1 << BarcodeFormat::AZTEC;
+const DecodeHintType DecodeHints::CODABAR_HINT = 1 << BarcodeFormat::CODABAR;
+const DecodeHintType DecodeHints::CODE_39_HINT = 1 << BarcodeFormat::CODE_39;
+const DecodeHintType DecodeHints::CODE_93_HINT = 1 << BarcodeFormat::CODE_93;
+const DecodeHintType DecodeHints::CODE_128_HINT = 1 << BarcodeFormat::CODE_128;
+const DecodeHintType DecodeHints::DATA_MATRIX_HINT = 1 << BarcodeFormat::DATA_MATRIX;
+const DecodeHintType DecodeHints::EAN_8_HINT = 1 << BarcodeFormat::EAN_8;
+const DecodeHintType DecodeHints::EAN_13_HINT = 1 << BarcodeFormat::EAN_13;
+const DecodeHintType DecodeHints::ITF_HINT = 1 << BarcodeFormat::ITF;
+const DecodeHintType DecodeHints::MAXICODE_HINT = 1 << BarcodeFormat::MAXICODE;
+const DecodeHintType DecodeHints::PDF_417_HINT = 1 << BarcodeFormat::PDF_417;
+const DecodeHintType DecodeHints::QR_CODE_HINT = 1 << BarcodeFormat::QR_CODE;
+const DecodeHintType DecodeHints::RSS_14_HINT = 1 << BarcodeFormat::RSS_14;
+const DecodeHintType DecodeHints::RSS_EXPANDED_HINT = 1 << BarcodeFormat::RSS_EXPANDED;
+const DecodeHintType DecodeHints::UPC_A_HINT = 1 << BarcodeFormat::UPC_A;
+const DecodeHintType DecodeHints::UPC_E_HINT = 1 << BarcodeFormat::UPC_E;
+const DecodeHintType DecodeHints::UPC_EAN_EXTENSION_HINT = 1 << BarcodeFormat::UPC_EAN_EXTENSION;
+
+const DecodeHintType DecodeHints::TRYHARDER_HINT = 1 << 31;
+const DecodeHintType DecodeHints::CHARACTER_SET = 1 << 30;
+const DecodeHintType DecodeHints::ALLOWED_LENGTHS = 1 << 29;
+const DecodeHintType DecodeHints::ASSUME_CODE_39_CHECK_DIGIT = 1 << 28;
+const DecodeHintType DecodeHints::ASSUME_GS1 = 1 << 27;
+const DecodeHintType DecodeHints::NEED_RESULT_POINT_CALLBACK = 1 << 26;
+
 
 const DecodeHints DecodeHints::PRODUCT_HINT(
   UPC_A_HINT |

--- a/core/src/zxing/DecodeHints.h
+++ b/core/src/zxing/DecodeHints.h
@@ -35,30 +35,30 @@ class DecodeHints {
   Ref<ResultPointCallback> callback;
 
  public:
-  static const DecodeHintType AZTEC_HINT = 1 << BarcodeFormat::AZTEC;
-  static const DecodeHintType CODABAR_HINT = 1 << BarcodeFormat::CODABAR;
-  static const DecodeHintType CODE_39_HINT = 1 << BarcodeFormat::CODE_39;
-  static const DecodeHintType CODE_93_HINT = 1 << BarcodeFormat::CODE_93;
-  static const DecodeHintType CODE_128_HINT = 1 << BarcodeFormat::CODE_128;
-  static const DecodeHintType DATA_MATRIX_HINT = 1 << BarcodeFormat::DATA_MATRIX;
-  static const DecodeHintType EAN_8_HINT = 1 << BarcodeFormat::EAN_8;
-  static const DecodeHintType EAN_13_HINT = 1 << BarcodeFormat::EAN_13;
-  static const DecodeHintType ITF_HINT = 1 << BarcodeFormat::ITF;
-  static const DecodeHintType MAXICODE_HINT = 1 << BarcodeFormat::MAXICODE;
-  static const DecodeHintType PDF_417_HINT = 1 << BarcodeFormat::PDF_417;
-  static const DecodeHintType QR_CODE_HINT = 1 << BarcodeFormat::QR_CODE;
-  static const DecodeHintType RSS_14_HINT = 1 << BarcodeFormat::RSS_14;
-  static const DecodeHintType RSS_EXPANDED_HINT = 1 << BarcodeFormat::RSS_EXPANDED;
-  static const DecodeHintType UPC_A_HINT = 1 << BarcodeFormat::UPC_A;
-  static const DecodeHintType UPC_E_HINT = 1 << BarcodeFormat::UPC_E;
-  static const DecodeHintType UPC_EAN_EXTENSION_HINT = 1 << BarcodeFormat::UPC_EAN_EXTENSION;
+  static const DecodeHintType AZTEC_HINT;
+  static const DecodeHintType CODABAR_HINT;
+  static const DecodeHintType CODE_39_HINT;
+  static const DecodeHintType CODE_93_HINT; 
+  static const DecodeHintType CODE_128_HINT;
+  static const DecodeHintType DATA_MATRIX_HINT;
+  static const DecodeHintType EAN_8_HINT;
+  static const DecodeHintType EAN_13_HINT;
+  static const DecodeHintType ITF_HINT;
+  static const DecodeHintType MAXICODE_HINT;
+  static const DecodeHintType PDF_417_HINT;
+  static const DecodeHintType QR_CODE_HINT;
+  static const DecodeHintType RSS_14_HINT;
+  static const DecodeHintType RSS_EXPANDED_HINT;
+  static const DecodeHintType UPC_A_HINT;
+  static const DecodeHintType UPC_E_HINT;
+  static const DecodeHintType UPC_EAN_EXTENSION_HINT;
 
-  static const DecodeHintType TRYHARDER_HINT = 1 << 31;
-  static const DecodeHintType CHARACTER_SET = 1 << 30;
-  // static const DecodeHintType ALLOWED_LENGTHS = 1 << 29;
-  // static const DecodeHintType ASSUME_CODE_39_CHECK_DIGIT = 1 << 28;
-  static const DecodeHintType  ASSUME_GS1 = 1 << 27;
-  // static const DecodeHintType NEED_RESULT_POINT_CALLBACK = 1 << 26;
+  static const DecodeHintType TRYHARDER_HINT;
+  static const DecodeHintType CHARACTER_SET;
+  static const DecodeHintType ALLOWED_LENGTHS;
+  static const DecodeHintType ASSUME_CODE_39_CHECK_DIGIT;
+  static const DecodeHintType  ASSUME_GS1;
+  static const DecodeHintType NEED_RESULT_POINT_CALLBACK;
   
   static const DecodeHints PRODUCT_HINT;
   static const DecodeHints ONED_HINT;


### PR DESCRIPTION
Put all declarations into the .cpp file. Did not work before with VS compiler if you added the static library into your own project. 

Error Code was:
error LNK2005: "public: static unsigned int const
zxing::DecodeHints::CHARACTER_SET" (?CHARACTER_SET@DecodeHints@zxing@@2IB) 
already defined in MyObject.obj 

Problem on stackoverflow (another author):
http://stackoverflow.com/questions/18208143/lnk2005-error-with-zxing-c
