### PR TITLE
FLT_MAX requires include <cfloat>

### DIFF
--- a/core/src/zxing/oned/OneDReader.cpp
+++ b/core/src/zxing/oned/OneDReader.cpp
@@ -23,6 +23,7 @@
 #include <math.h>
 #include <limits.h>
 #include <algorithm>
+#include <cfloat>
 
 using std::vector;
 using zxing::Ref;


### PR DESCRIPTION
Fixes error: 'FLT_MAX' was not declared in this scope.
Tested on gcc 4.7 on armv7 & gcc 4.9 on x64

Signed-off-by: Matthieu Crapet <mcrapet@gmail.com>