### PR TITLE
Fix for compilation errors when using zxing-cpp

### DIFF
--- a/core/src/zxing/LuminanceSource.h
+++ b/core/src/zxing/LuminanceSource.h
@@ -27,7 +27,7 @@
 namespace zxing {
 
 class LuminanceSource : public Counted {
- private:
+ public:
   const int width;
   const int height;
 


### PR DESCRIPTION
In the class LuminanceSource line 30  has been edited to public variable from private. To fix compile errors with some OSs.