### PR TITLE
Build system tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,9 @@ include(source_files.cmake)
 
 if(WIN32)
     include_directories(core/lib/win32)
-    set(CMAKE_DEBUG_POSTFIX -debug)
+    if(CMAKE_BUILD_TYPE EQUAL Debug)
+        set(CMAKE_DEBUG_POSTFIX d)
+    endif()
 endif()
 
 # OpenCV classes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if(WIN32)
 endif()
 
 # OpenCV classes
-find_package(OpenCV)
+find_package(OpenCV QUIET)
 if(OpenCV_FOUND)
     list(APPEND LIBZXING_FILES
         opencv/src/zxing/MatSource.cpp
@@ -58,7 +58,7 @@ include_directories(core/src)
 add_library(libzxing ${LIBZXING_FILES})
 set_target_properties(libzxing PROPERTIES PREFIX "")
 
-find_package(Iconv)
+find_package(Iconv QUIET)
 if(ICONV_FOUND)
     include_directories(${ICONV_INCLUDE_DIR})
     target_link_libraries(libzxing ${ICONV_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,15 @@ if(OpenCV_FOUND)
 endif()
 
 include_directories(core/src)
-add_library(libzxing ${LIBZXING_FILES})
+add_library(libzxing SHARED ${LIBZXING_FILES})
 set_target_properties(libzxing PROPERTIES PREFIX "")
+
+include(GenerateExportHeader)
+generate_export_header(libzxing EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/zxing_export.h)
+target_include_directories(libzxing PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
 
 find_package(Iconv QUIET)
 if(ICONV_FOUND)
@@ -87,13 +94,15 @@ file(GLOB_RECURSE ZXING_FILES
 add_executable(zxing ${ZXING_FILES})
 target_link_libraries(zxing libzxing)
 
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zxing_export.h
+    DESTINATION include
+)
 install(TARGETS zxing libzxing EXPORT zxing-targets
-	LIBRARY DESTINATION lib
-	RUNTIME DESTINATION bin
-	ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+    ARCHIVE DESTINATION lib
     INCLUDES DESTINATION include
 )
-
 install(EXPORT zxing-targets DESTINATION lib/zxing/cmake NAMESPACE zxing::)
 
 install(

--- a/core/src/zxing/BarcodeFormat.h
+++ b/core/src/zxing/BarcodeFormat.h
@@ -21,6 +21,8 @@
  * limitations under the License.
  */
 
+#include <zxing_export.h>
+
 namespace zxing {
 
 class BarcodeFormat {
@@ -48,11 +50,11 @@ public:
     UPC_EAN_EXTENSION
   };
 
-  BarcodeFormat(Value v) : value(v) {}  
+  BarcodeFormat(Value v) : value(v) {}
   const Value value;
   operator Value () const {return value;}
 
-  static char const* barcodeFormatNames[];
+  static LIBZXING_EXPORT char const* barcodeFormatNames[];
 };
 
 }

--- a/core/src/zxing/DecodeHints.h
+++ b/core/src/zxing/DecodeHints.h
@@ -20,6 +20,7 @@
  * limitations under the License.
  */
 
+#include <zxing_export.h>
 #include <zxing/BarcodeFormat.h>
 #include <zxing/ResultPointCallback.h>
 
@@ -35,34 +36,34 @@ class DecodeHints {
   Ref<ResultPointCallback> callback;
 
  public:
-  static const DecodeHintType AZTEC_HINT = 1 << BarcodeFormat::AZTEC;
-  static const DecodeHintType CODABAR_HINT = 1 << BarcodeFormat::CODABAR;
-  static const DecodeHintType CODE_39_HINT = 1 << BarcodeFormat::CODE_39;
-  static const DecodeHintType CODE_93_HINT = 1 << BarcodeFormat::CODE_93;
-  static const DecodeHintType CODE_128_HINT = 1 << BarcodeFormat::CODE_128;
-  static const DecodeHintType DATA_MATRIX_HINT = 1 << BarcodeFormat::DATA_MATRIX;
-  static const DecodeHintType EAN_8_HINT = 1 << BarcodeFormat::EAN_8;
-  static const DecodeHintType EAN_13_HINT = 1 << BarcodeFormat::EAN_13;
-  static const DecodeHintType ITF_HINT = 1 << BarcodeFormat::ITF;
-  static const DecodeHintType MAXICODE_HINT = 1 << BarcodeFormat::MAXICODE;
-  static const DecodeHintType PDF_417_HINT = 1 << BarcodeFormat::PDF_417;
-  static const DecodeHintType QR_CODE_HINT = 1 << BarcodeFormat::QR_CODE;
-  static const DecodeHintType RSS_14_HINT = 1 << BarcodeFormat::RSS_14;
-  static const DecodeHintType RSS_EXPANDED_HINT = 1 << BarcodeFormat::RSS_EXPANDED;
-  static const DecodeHintType UPC_A_HINT = 1 << BarcodeFormat::UPC_A;
-  static const DecodeHintType UPC_E_HINT = 1 << BarcodeFormat::UPC_E;
-  static const DecodeHintType UPC_EAN_EXTENSION_HINT = 1 << BarcodeFormat::UPC_EAN_EXTENSION;
+  static LIBZXING_EXPORT const DecodeHintType AZTEC_HINT = 1 << BarcodeFormat::AZTEC;
+  static LIBZXING_EXPORT const DecodeHintType CODABAR_HINT = 1 << BarcodeFormat::CODABAR;
+  static LIBZXING_EXPORT const DecodeHintType CODE_39_HINT = 1 << BarcodeFormat::CODE_39;
+  static LIBZXING_EXPORT const DecodeHintType CODE_93_HINT = 1 << BarcodeFormat::CODE_93;
+  static LIBZXING_EXPORT const DecodeHintType CODE_128_HINT = 1 << BarcodeFormat::CODE_128;
+  static LIBZXING_EXPORT const DecodeHintType DATA_MATRIX_HINT = 1 << BarcodeFormat::DATA_MATRIX;
+  static LIBZXING_EXPORT const DecodeHintType EAN_8_HINT = 1 << BarcodeFormat::EAN_8;
+  static LIBZXING_EXPORT const DecodeHintType EAN_13_HINT = 1 << BarcodeFormat::EAN_13;
+  static LIBZXING_EXPORT const DecodeHintType ITF_HINT = 1 << BarcodeFormat::ITF;
+  static LIBZXING_EXPORT const DecodeHintType MAXICODE_HINT = 1 << BarcodeFormat::MAXICODE;
+  static LIBZXING_EXPORT const DecodeHintType PDF_417_HINT = 1 << BarcodeFormat::PDF_417;
+  static LIBZXING_EXPORT const DecodeHintType QR_CODE_HINT = 1 << BarcodeFormat::QR_CODE;
+  static LIBZXING_EXPORT const DecodeHintType RSS_14_HINT = 1 << BarcodeFormat::RSS_14;
+  static LIBZXING_EXPORT const DecodeHintType RSS_EXPANDED_HINT = 1 << BarcodeFormat::RSS_EXPANDED;
+  static LIBZXING_EXPORT const DecodeHintType UPC_A_HINT = 1 << BarcodeFormat::UPC_A;
+  static LIBZXING_EXPORT const DecodeHintType UPC_E_HINT = 1 << BarcodeFormat::UPC_E;
+  static LIBZXING_EXPORT const DecodeHintType UPC_EAN_EXTENSION_HINT = 1 << BarcodeFormat::UPC_EAN_EXTENSION;
 
-  static const DecodeHintType TRYHARDER_HINT = 1 << 31;
-  static const DecodeHintType CHARACTER_SET = 1 << 30;
-  // static const DecodeHintType ALLOWED_LENGTHS = 1 << 29;
-  // static const DecodeHintType ASSUME_CODE_39_CHECK_DIGIT = 1 << 28;
-  static const DecodeHintType  ASSUME_GS1 = 1 << 27;
-  // static const DecodeHintType NEED_RESULT_POINT_CALLBACK = 1 << 26;
-  
-  static const DecodeHints PRODUCT_HINT;
-  static const DecodeHints ONED_HINT;
-  static const DecodeHints DEFAULT_HINT;
+  static LIBZXING_EXPORT const DecodeHintType TRYHARDER_HINT = 1 << 31;
+  static LIBZXING_EXPORT const DecodeHintType CHARACTER_SET = 1 << 30;
+  // static LIBZXING_EXPORT const DecodeHintType ALLOWED_LENGTHS = 1 << 29;
+  // static LIBZXING_EXPORT const DecodeHintType ASSUME_CODE_39_CHECK_DIGIT = 1 << 28;
+  static LIBZXING_EXPORT const DecodeHintType  ASSUME_GS1 = 1 << 27;
+  // static LIBZXING_EXPORT const DecodeHintType NEED_RESULT_POINT_CALLBACK = 1 << 26;
+
+  static LIBZXING_EXPORT const DecodeHints PRODUCT_HINT;
+  static LIBZXING_EXPORT const DecodeHints ONED_HINT;
+  static LIBZXING_EXPORT const DecodeHints DEFAULT_HINT;
 
   DecodeHints();
   DecodeHints(DecodeHintType init);


### PR DESCRIPTION
This PR fixes a few issues I encountered while building the library:
- Find optional libraries is turned to quiet, so if OpenCV or Iconv are not detected the respective modules are not built silently. Previously it would fail the compilation.
- Build `libzxing` as a shared library, makes it easier to link against shared library (no need to build in PIC mode).
- Symbols are exported correctly when compiling on Windows MSVC2017.