### PR TITLE
Fixes missing header include

### DIFF
--- a/core/src/zxing/pdf417/decoder/Decoder.h
+++ b/core/src/zxing/pdf417/decoder/Decoder.h
@@ -25,8 +25,9 @@
 #include <zxing/pdf417/decoder/ec/ModulusGF.h>
 #include <zxing/common/Counted.h>
 #include <zxing/common/Array.h>
-#include <zxing/common/DecoderResult.h>
 #include <zxing/common/BitMatrix.h>
+#include <zxing/common/DecoderResult.h>
+#include <zxing/DecodeHints.h>
 
 
 namespace zxing {


### PR DESCRIPTION
`DecodeHints` is used below, but not included