### PR TITLE
In qrcode, use the more specific NotFoundException.

### DIFF
--- a/core/src/zxing/MultiFormatReader.cpp
+++ b/core/src/zxing/MultiFormatReader.cpp
@@ -24,6 +24,7 @@
 #include <zxing/oned/MultiFormatUPCEANReader.h>
 #include <zxing/oned/MultiFormatOneDReader.h>
 #include <zxing/ReaderException.h>
+#include <zxing/NotFoundException.h>
 
 using zxing::Ref;
 using zxing::Result;
@@ -118,7 +119,7 @@ Ref<Result> MultiFormatReader::decodeInternal(Ref<BinaryBitmap> image) {
       // continue
     }
   }
-  throw ReaderException("No code detected");
+  throw NotFoundException("No code detected");
 }
   
 MultiFormatReader::~MultiFormatReader() {}

--- a/core/src/zxing/multi/GenericMultipleBarcodeReader.cpp
+++ b/core/src/zxing/multi/GenericMultipleBarcodeReader.cpp
@@ -16,7 +16,7 @@
  */
 
 #include <zxing/multi/GenericMultipleBarcodeReader.h>
-#include <zxing/ReaderException.h>
+#include <zxing/NotFoundException.h>
 #include <zxing/ResultPoint.h>
 
 using std::vector;
@@ -39,7 +39,7 @@ vector<Ref<Result> > GenericMultipleBarcodeReader::decodeMultiple(Ref<BinaryBitm
   vector<Ref<Result> > results;
   doDecodeMultiple(image, hints, results, 0, 0, 0);
   if (results.empty()){
-    throw ReaderException("No code detected");
+    throw NotFoundException("No code detected");
   }
   return results;
 }

--- a/core/src/zxing/multi/qrcode/QRCodeMultiReader.cpp
+++ b/core/src/zxing/multi/qrcode/QRCodeMultiReader.cpp
@@ -17,6 +17,7 @@
 
 #include <zxing/multi/qrcode/QRCodeMultiReader.h>
 #include <zxing/ReaderException.h>
+#include <zxing/NotFoundException.h>
 #include <zxing/multi/qrcode/detector/MultiDetector.h>
 #include <zxing/BarcodeFormat.h>
 
@@ -49,7 +50,7 @@ std::vector<Ref<Result> > QRCodeMultiReader::decodeMultiple(Ref<BinaryBitmap> im
     }
   }
   if (results.empty()){
-    throw ReaderException("No code detected");
+    throw NotFoundException("No code detected");
   }
   return results;
 }

--- a/core/src/zxing/multi/qrcode/detector/MultiFinderPatternFinder.cpp
+++ b/core/src/zxing/multi/qrcode/detector/MultiFinderPatternFinder.cpp
@@ -19,7 +19,7 @@
 #include <algorithm>
 #include <zxing/multi/qrcode/detector/MultiFinderPatternFinder.h>
 #include <zxing/DecodeHints.h>
-#include <zxing/ReaderException.h>
+#include <zxing/NotFoundException.h>
 
 using std::abs;
 using std::min;
@@ -27,7 +27,7 @@ using std::sort;
 using std::vector;
 using zxing::Ref;
 using zxing::BitMatrix;
-using zxing::ReaderException;
+using zxing::NotFoundException;
 using zxing::qrcode::FinderPattern;
 using zxing::qrcode::FinderPatternInfo;
 using zxing::multi::MultiFinderPatternFinder;
@@ -142,7 +142,7 @@ vector<vector<Ref<FinderPattern> > > MultiFinderPatternFinder::selectBestPattern
 
   if (size < 3) {
     // Couldn't find enough finder patterns
-    throw ReaderException("No code detected");
+    throw NotFoundException("No code detected");
   }
   
   vector<vector<Ref<FinderPattern> > > results;
@@ -230,7 +230,7 @@ vector<vector<Ref<FinderPattern> > > MultiFinderPatternFinder::selectBestPattern
   } // end iterate p1
   if (results.empty()){
     // Nothing found!
-    throw ReaderException("No code detected");    
+    throw NotFoundException("No code detected");
   }
   return results;
 }


### PR DESCRIPTION
NotFound is the *typical* case for a QR code reader. ReaderException covers a lot of other
genuinely exceptional cases though. It is useful to distinguish them.